### PR TITLE
Update vue-router to be compatible with vue 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "vue-papa-parse": "^3.0.4",
         "vue-progressive-image": "^3.2.0",
         "vue-property-decorator": "^10.0.0-rc.2",
-        "vue-router": "^3.5.3",
+        "vue-router": "^4.2.4",
         "vue-scrollama": "^2.0.2",
         "vue-tippy": "^4.10.0"
     },

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,19 +1,12 @@
 <template>
     <div id="app" class="storyramp-app bg-white">
-        <!-- <router-view :key="$route.path"></router-view> -->
-        <story></story>
+        <router-view :key="$route.path"></router-view>
     </div>
 </template>
 
 <script lang="ts">
-import { Options, Vue } from 'vue-property-decorator';
-import StoryV from '@storylines/components/story/story.vue';
+import { Vue } from 'vue-property-decorator';
 
-@Options({
-    components: {
-        story: StoryV
-    }
-})
 export default class App extends Vue {}
 </script>
 

--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -93,7 +93,7 @@ export default class VideoPanelV extends Vue {
     transcriptContent = '';
 
     created(): void {
-        this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
+        this.lang = (this.$route.params.lang as string) ? (this.$route.params.lang as string) : 'en';
 
         // find file type extension for non-YT videos
         if (this.config.videoType === 'external' || this.config.videoType === 'local') {

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -61,7 +61,7 @@
 
 <script lang="ts">
 import { Options, Vue } from 'vue-property-decorator';
-import { Route } from 'vue-router';
+import { RouteLocationNormalized } from 'vue-router';
 
 import MobileMenuV from './mobile-menu.vue';
 import StoryContentV from '@storylines/components/story/story-content.vue';
@@ -85,8 +85,8 @@ export default class StoryV extends Vue {
     lang = 'en';
 
     created(): void {
-        const uid = this.$route.params.uid;
-        this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
+        const uid = this.$route.params.uid as string;
+        this.lang = (this.$route.params.lang as string) ? (this.$route.params.lang as string) : 'en';
         if (uid) {
             this.fetchConfig(uid, this.lang);
         } else {
@@ -102,9 +102,9 @@ export default class StoryV extends Vue {
     }
 
     // react to param changes in URL
-    beforeRouteUpdate(to: Route, from: Route, next: () => void): void {
-        const uid = to.params.uid;
-        this.lang = to.params.lang;
+    beforeRouteUpdate(to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void {
+        const uid = to.params.uid as string;
+        this.lang = to.params.lang as string;
         this.$i18n.locale = this.lang;
         this.fetchConfig(uid, this.lang);
         next();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import './router/componentHooks';
 import { createApp } from 'vue';
 import App from './app.vue';
-// import router from './router';
+import router from './router';
 import './style.css';
 
 // import { i18n } from './lang';
@@ -16,4 +16,10 @@ const app = createApp(App);
 
 app.component('tippy', TippyComponent);
 
-app.use(VueTippy).use(HighchartsVue).use(VuePapaParse).use(VueProgressiveImage).use(VueFullScreen).mount('#app');
+app.use(router)
+    .use(VueTippy)
+    .use(HighchartsVue)
+    .use(VuePapaParse)
+    .use(VueProgressiveImage)
+    .use(VueFullScreen)
+    .mount('#app');

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,5 @@
 import StoryV from '@storylines/components/story/story.vue';
-import Router, { Route } from 'vue-router';
+import { createRouter, createWebHashHistory, RouteLocationNormalized } from 'vue-router';
 
 const routes = [
     {
@@ -16,10 +16,11 @@ const routes = [
     }
 ];
 
-export default new Router({
+const router = createRouter({
     routes: routes,
     // mode: 'history', // TODO: uncomment to change to history mode for nicer URLs (eliminating middle hash) see #100
-    scrollBehavior: function (to: Route) {
+    history: createWebHashHistory(),
+    scrollBehavior: function (to: RouteLocationNormalized) {
         if (to.hash) {
             return {
                 selector: decodeURIComponent(to.hash),
@@ -28,3 +29,5 @@ export default new Router({
         }
     }
 });
+
+export default router;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,9 +1,9 @@
 import { VuePapaParse } from 'vue-papa-parse';
-import { Route } from 'vue-router';
+import { RouteLocationNormalized } from 'vue-router';
 
 declare module 'vue/types/vue' {
     interface Vue {
         $papa: VuePapaParse;
-        $route: Route;
+        $route: RouteLocationNormalized;
     }
 }


### PR DESCRIPTION
This PR updates vue-router to version 4.2.4 to be compatible with vue 3, and should remove any errors coming from vue-router.

One thing to note is that at the bottom of the [migration guide](https://router.vuejs.org/guide/migration/) the `Route` type was renamed to `RouteLocationNormalized`. However `RouteLocationNormalized` defined parameters like `lang` and `uid` as eithier a string or a string array, while `Route` defined them as just a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/story-ramp/3)
<!-- Reviewable:end -->
