### PR TITLE
Replace vue-loading-spinner package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
                 "vue-router": "^4.2.4",
                 "vue-tippy": "^6.3.1",
                 "vue3-carousel": "^0.3.1",
-                "vue3-scrollama": "^0.2.2"
+                "vue3-scrollama": "^0.2.2",
+                "vue3-spinners": "^1.2.2"
             },
             "devDependencies": {
                 "@types/markdown-it": "^12.0.1",
@@ -5708,6 +5709,11 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
             "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
         },
+        "node_modules/colornames": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+            "integrity": "sha512-/pyV40IrsdulWv+wFPmERh9k/mjsPZ64yUMDmWrtj/k1nmgrzzIENWKdaVKyBbvFdQWqkcaRxr+polCo3VMe7A=="
+        },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -10863,6 +10869,16 @@
                 "setimmediate": "^1.0.5"
             }
         },
+        "node_modules/just-range": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/just-range/-/just-range-4.2.0.tgz",
+            "integrity": "sha512-z2Ip8H2j7a9Vr8rKFi0IZf4IXn2Yuq2lGZFS41GjfPwksoHWTaTx1xIjU6C0HyQ1jBXEoz/FzjS5eyVXeW19tg=="
+        },
+        "node_modules/just-zip-it": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/just-zip-it/-/just-zip-it-3.2.0.tgz",
+            "integrity": "sha512-ZJxc8mLz8XkaoOegJ237Xuo3ZQB5zUN/8BTXqalBJbh/uj+ahfJbOJKadJPmXDBbxHzh+MQYH43VxV5TlQvlfw=="
+        },
         "node_modules/killable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -12181,6 +12197,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/outdent": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+            "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
+        },
         "node_modules/p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12308,6 +12329,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/parse-unit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+            "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg=="
         },
         "node_modules/parse5": {
             "version": "5.1.1",
@@ -16386,6 +16412,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/style-inject": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
+            "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw=="
+        },
         "node_modules/stylehacks": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -18300,6 +18331,22 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/scrollama/-/scrollama-3.2.0.tgz",
             "integrity": "sha512-PIPwB1kYBnbw/ezvPBJa5dCN5qEwokfpAkI3BmpZWAwcVID4nDf1qH6WV16A2fQaJmsKx0un5S/zhxN+PQeKDQ=="
+        },
+        "node_modules/vue3-spinners": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/vue3-spinners/-/vue3-spinners-1.2.2.tgz",
+            "integrity": "sha512-rWYvbwgLKQOWk92pzadYCSssYeMJdyCfdT3ZAPHwT9lOU2+jPtGvp1tr2wQHQejlLTjaF4sHIBWVq4QGuCWGDg==",
+            "dependencies": {
+                "colornames": "^1.1.1",
+                "just-range": "^4.0.1",
+                "just-zip-it": "^3.0.2",
+                "outdent": "^0.8.0",
+                "parse-unit": "^1.0.1",
+                "style-inject": "^0.3.0"
+            },
+            "peerDependencies": {
+                "vue": "^3"
+            }
         },
         "node_modules/watchpack": {
             "version": "1.7.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "vue-router": "^4.2.4",
         "vue-tippy": "^6.3.1",
         "vue3-carousel": "^0.3.1",
-        "vue3-scrollama": "^0.2.2"
+        "vue3-scrollama": "^0.2.2",
+        "vue3-spinners": "^1.2.2"
     },
     "devDependencies": {
         "@types/markdown-it": "^12.0.1",

--- a/src/components/panels/loading-panel.vue
+++ b/src/components/panels/loading-panel.vue
@@ -1,7 +1,7 @@
 <template>
     <VueScrollama class="flex-1 prose max-w-none my-5">
         <div class="block py-20 align-middle text-center h-full" style="margin: 0 auto">
-            <!-- <spinner size="120px" background="#00D2D3" color="#009cd1" stroke="10px" style="margin: 0 auto"></spinner> -->
+            <spinner size="120px" color="#009cd1" style="margin: 0 auto"></spinner>
         </div>
     </VueScrollama>
 </template>
@@ -9,12 +9,12 @@
 <script lang="ts">
 import VueScrollama from 'vue3-scrollama';
 import { Options, Vue } from 'vue-property-decorator';
-// import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+import { VueSpinnerOval } from 'vue3-spinners';
 
 @Options({
     components: {
-        VueScrollama
-        // spinner: Circle2
+        VueScrollama,
+        spinner: VueSpinnerOval
     }
 })
 export default class LoadingPanelV extends Vue {}

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -2,7 +2,7 @@
     <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
     <div v-if="loadStatus === 'loading'">
         <div class="block py-20 align-middle text-center h-full" style="margin: 0 auto">
-            <!-- <spinner size="120px" background="#00D2D3" color="#009cd1" stroke="10px" style="margin: 0 auto"></spinner> -->
+            <spinner size="120px" color="#009cd1" style="margin: 0 auto"></spinner>
         </div>
     </div>
 
@@ -68,14 +68,14 @@ import StoryContentV from '@storylines/components/story/story-content.vue';
 import IntroV from '@storylines/components/story/introduction.vue';
 
 import { StoryRampConfig } from '@storylines/definitions';
-// import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+import { VueSpinnerOval } from 'vue3-spinners';
 
 @Options({
     components: {
         StoryContentV,
         MobileMenuV,
-        introduction: IntroV
-        // spinner: Circle2
+        introduction: IntroV,
+        spinner: VueSpinnerOval
     }
 })
 export default class StoryV extends Vue {


### PR DESCRIPTION
This PR replaces `vue-loading-spinner` with a similar vue3 compatible package [vue3-spinners](https://www.npmjs.com/package/vue3-spinners?activeTab=readme).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yileifeng/story-ramp/8)
<!-- Reviewable:end -->
